### PR TITLE
set "thiserror" as a default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.56"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["thiserror"]
 thiserror = ["dep:thiserror", "tosserror-derive/thiserror"]
 
 [dependencies]


### PR DESCRIPTION
This change would re-export `thiserror::Error` as `tosserror::Error` so that you don't have to depend on `thiserror` as a dependency anymore.

Example code:

```rust
use tosserror::{Error, Toss};

#[derive(Error, Toss, Debug)]
pub enum DataStoreError {
    #[error("invalid value ({value}) encountered")]
    InvalidValue {
      value: i32,
      source: std::num::TryFromIntError,
    },
}
```

